### PR TITLE
Update to new Procursus bootstrap folder

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
       if: steps.information.outputs.procursus_bootstrapped != 'true' && (inputs.cache != 'true' || steps.procursus-cache.outputs.cache-hit != 'true')
       shell: bash
       run: |
-        curl -L ${{ inputs.mirror }}/bootstrap_darwin-amd64.tar.zst | zstdcat - | sudo tar -xpkf - -C / || :
+        curl -L ${{ inputs.mirror }}/bootstraps/${{ inputs.suites }}/bootstrap-darwin-amd64.tar.zst | zstdcat - | sudo tar -xpkf - -C / || :
 
     - name: Restore bootstrap from cache
       if: steps.information.outputs.procursus_bootstrapped != 'true' && (inputs.cache == 'true' && steps.procursus-cache.outputs.cache-hit == 'true')


### PR DESCRIPTION
Procursus moved the bootstraps, so this change is needed for the action to run.